### PR TITLE
Abbreviations fixed #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ venv.bak/
 docs/.ipynb_checkpoints/*
 
 
+/tst.py

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,26 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="126" name="Python" />
+      </Languages>
+    </inspection_tool>
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="typing_extensions" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E501" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="piecewise-regression" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (piecewise-regression)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/piecewise-regression.iml" filepath="$PROJECT_DIR$/.idea/piecewise-regression.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PySciProjectComponent">
+    <option name="PY_MATPLOTLIB_IN_TOOLWINDOW" value="false" />
+    <option name="PY_INTERACTIVE_PLOTS" value="false" />
+  </component>
+</project>

--- a/.idea/piecewise-regression.iml
+++ b/.idea/piecewise-regression.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.9 (piecewise-regression)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/piecewise_regression/main.py
+++ b/piecewise_regression/main.py
@@ -227,18 +227,18 @@ class NextBreakpoints:
         Save to the self.estimates dictionary
         """
         const_ses = self.get_const_standard_error()
-        self.estimates["const"]["se"] = const_ses
+        self.estimates["const"]["standard_error"] = const_ses
 
         beta_ses = self.get_beta_standard_errors()
         bp_ses = self.get_bp_standard_errors()
         for bp_i in range(self.n_breakpoints):
-            self.estimates["beta{}".format(bp_i + 1)]["se"] = beta_ses[bp_i]
+            self.estimates["beta{}".format(bp_i + 1)]["standard_error"] = beta_ses[bp_i]
             self.estimates["breakpoint{}".format(
-                bp_i + 1)]["se"] = bp_ses[bp_i]
+                bp_i + 1)]["standard_error"] = bp_ses[bp_i]
         alpha_ses = self.get_alpha_standard_errors()
         for alpha_i in range(self.n_breakpoints + 1):
             self.estimates["alpha{}".format(
-                alpha_i + 1)]["se"] = alpha_ses[alpha_i]
+                alpha_i + 1)]["standard_error"] = alpha_ses[alpha_i]
 
     def calculate_all_confidence_intervals(self):
         """
@@ -253,8 +253,8 @@ class NextBreakpoints:
         # to all estimators
         for estimator_name, details in self.estimates.items():
             confidence_interval = (
-                details["estimate"] - t_const * details["se"],
-                details["estimate"] + t_const * details["se"])
+                details["estimate"] - t_const * details["standard_error"],
+                details["estimate"] + t_const * details["standard_error"])
             details["confidence_interval"] = confidence_interval
 
     def calculate_all_t_stats(self):
@@ -268,15 +268,15 @@ class NextBreakpoints:
             # H_0 isn't bp=0, it's that bp doesn't exist
             if "breakpoint" in estimator_name:
                 details["t_stat"] = "-"
-                details["p_t"] = "-"
+                details["p_t_stat"] = "-"
             else:
-                t_stat = details["estimate"] / details["se"]
+                t_stat = details["estimate"] / details["standard_error"]
                 p_t = scipy.stats.t.sf(np.abs(t_stat), dof) * 2
                 details["t_stat"] = t_stat
                 if "beta" in estimator_name:
-                    details["p_t"] = "-"
+                    details["p_t_stat"] = "-"
                 else:
-                    details["p_t"] = p_t
+                    details["p_t_stat"] = p_t
 
     def get_predicted_yy(self):
         """
@@ -724,14 +724,14 @@ class Fit:
 
         if self.best_muggeo:
             results["estimates"] = self.best_muggeo.best_fit.estimates
-            results["bic"] = self.best_muggeo.best_fit.bic
-            results["rss"] = self.best_muggeo.best_fit.residual_sum_squares
+            results["bayesian_information_criterion"] = self.best_muggeo.best_fit.bic
+            results["residual_sum_of_squares"] = self.best_muggeo.best_fit.residual_sum_squares
             results["converged"] = True
         else:
             results["converged"] = False
             results["estimates"] = None
-            results["bic"] = None
-            results["rss"] = None
+            results["bayesian_information_criterion"] = None
+            results["residual_sum_of_squares"] = None
         return results
 
     def get_params(self):
@@ -1115,9 +1115,9 @@ class Fit:
                 estimator_row = table_row_template.format(
                     est_name,
                     estimates[est_name]["estimate"],
-                    estimates[est_name]["se"],
+                    estimates[est_name]["standard_error"],
                     estimates[est_name]["t_stat"],
-                    estimates[est_name]["p_t"],
+                    estimates[est_name]["p_t_stat"],
                     estimates[est_name]["confidence_interval"][0],
                     estimates[est_name]["confidence_interval"][1])
                 table_contents += estimator_row
@@ -1136,8 +1136,8 @@ class Fit:
             for est_name in alpha_names:
                 estimator_row = table_row_template.format(
                     est_name, estimates[est_name]["estimate"],
-                    estimates[est_name]["se"],
-                    estimates[est_name]["t_stat"], estimates[est_name]["p_t"],
+                    estimates[est_name]["standard_error"],
+                    estimates[est_name]["t_stat"], estimates[est_name]["p_t_stat"],
                     estimates[est_name]["confidence_interval"][0],
                     estimates[est_name]["confidence_interval"][1])
                 table_contents += estimator_row

--- a/piecewise_regression/model_selection.py
+++ b/piecewise_regression/model_selection.py
@@ -73,11 +73,13 @@ class ModelSelection:
         for model_summary in self.model_summaries:
 
             if model_summary["converged"]:
+                print("=" * 200)
+                print(model_summary)
                 model_row = table_row_template.format(
                     model_summary["n_breakpoints"], 
-                    model_summary["bic"],
+                    model_summary["bayesian_information_criterion"],
                     str(model_summary["converged"]), 
-                    model_summary["rss"])
+                    model_summary["residual_sum_of_squares"])
             else:
                 model_row = table_row_template.format(
                     model_summary["n_breakpoints"], "", 
@@ -110,11 +112,11 @@ class ModelSelection:
         bic = n * np.log(rss / n) + k * np.log(n)
 
         fit_data = {
-            "bic": bic,
+            "bayesian_information_criterion": bic,
             "n_breakpoints": 0,
             "estimates": {},
             "converged": True,
-            "rss": rss
+            "residual_sum_of_squares": rss
         }
 
         fit_data["estimates"]["const"] = results.params[0]

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -94,17 +94,17 @@ class TestFit(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp2, estimates["breakpoint2"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta2_se, estimates["beta2"]["se"], places=1)
+            muggeo_beta2_se, estimates["beta2"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp2_se, estimates["breakpoint2"]["se"], places=1)
+            muggeo_bp2_se, estimates["breakpoint2"]["standard_error"], places=1)
 
         self.assertAlmostEqual(
             muggeo_c_t, estimates["const"]["t_stat"], delta=1)
@@ -138,17 +138,17 @@ class TestFit(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp2, estimates["breakpoint2"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta2_se, estimates["beta2"]["se"], places=1)
+            muggeo_beta2_se, estimates["beta2"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp2_se, estimates["breakpoint2"]["se"], places=1)
+            muggeo_bp2_se, estimates["breakpoint2"]["standard_error"], places=1)
 
         self.assertAlmostEqual(
             muggeo_c_t, estimates["const"]["t_stat"], delta=1)
@@ -214,13 +214,13 @@ class TestFit(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp1, estimates["breakpoint1"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
 
         self.assertAlmostEqual(
             muggeo_c_t, estimates["const"]["t_stat"], delta=1)
@@ -289,13 +289,13 @@ class TestFit(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp1, estimates["breakpoint1"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
 
         self.assertAlmostEqual(
             muggeo_c_t, estimates["const"]["t_stat"], delta=1)
@@ -393,8 +393,8 @@ class TestFit(unittest.TestCase):
 
         self.assertEqual(results["converged"], False)
         self.assertEqual(results["estimates"], None)
-        self.assertEqual(results["bic"], None)
-        self.assertEqual(results["rss"], None)
+        self.assertEqual(results["bayesian_information_criterion"], None)
+        self.assertEqual(results["residual_sum_of_squares"], None)
 
 
 class TestPlots(unittest.TestCase):

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -7,6 +7,7 @@ from importlib.machinery import SourceFileLoader
 
 import os
 import sys
+
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
 DATA_SOURCE = "tests/data/data.txt"
@@ -32,15 +33,15 @@ class TestFit(unittest.TestCase):
         ms = ModelSelection(xx, yy, n_boot=20)
 
         # For each n_breakpoints, chekc the ModelSelection vs fit results
-        for n_breakpoints in range(1,10):
+        for n_breakpoints in range(1, 10):
             fit = Fit(xx, yy, n_breakpoints=n_breakpoints, verbose=False, n_boot=20)
 
             fit_converged = fit.get_results()["converged"]
             ms_converged = ms.model_summaries[n_breakpoints]["converged"]
             print(n_breakpoints, fit_converged, ms_converged)
-            
 
             self.assertEqual(fit_converged, ms_converged)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_muggeo.py
+++ b/tests/test_muggeo.py
@@ -78,17 +78,17 @@ class TestMuggeo(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp2, estimates["breakpoint2"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta2_se, estimates["beta2"]["se"], places=1)
+            muggeo_beta2_se, estimates["beta2"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp2_se, estimates["breakpoint2"]["se"], places=1)
+            muggeo_bp2_se, estimates["breakpoint2"]["standard_error"], places=1)
 
         print(estimates)
 
@@ -163,13 +163,13 @@ class TestMuggeo(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp1, estimates["breakpoint1"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
 
         self.assertAlmostEqual(
             muggeo_c_t, estimates["const"]["t_stat"], delta=1)

--- a/tests/test_next_breakpoint.py
+++ b/tests/test_next_breakpoint.py
@@ -77,17 +77,17 @@ class TestNextBreakpoint(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp2, estimates["breakpoint2"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta2_se, estimates["beta2"]["se"], places=1)
+            muggeo_beta2_se, estimates["beta2"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp2_se, estimates["breakpoint2"]["se"], places=1)
+            muggeo_bp2_se, estimates["breakpoint2"]["standard_error"], places=1)
 
         self.assertAlmostEqual(
             muggeo_c_t, estimates["const"]["t_stat"], delta=1)
@@ -158,13 +158,13 @@ class TestNextBreakpoint(unittest.TestCase):
         self.assertAlmostEqual(
             muggeo_bp1, estimates["breakpoint1"]["estimate"], places=1)
 
-        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["se"], places=1)
+        self.assertAlmostEqual(muggeo_c_se, estimates["const"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_alpha_se, estimates["alpha1"]["se"], places=1)
+            muggeo_alpha_se, estimates["alpha1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_beta1_se, estimates["beta1"]["se"], places=1)
+            muggeo_beta1_se, estimates["beta1"]["standard_error"], places=1)
         self.assertAlmostEqual(
-            muggeo_bp1_se, estimates["breakpoint1"]["se"], places=1)
+            muggeo_bp1_se, estimates["breakpoint1"]["standard_error"], places=1)
 
         self.assertAlmostEqual(
             muggeo_c_t, estimates["const"]["t_stat"], delta=1)


### PR DESCRIPTION
See the issue #17. This commit changes all abbreviations to its actual name and fixes tests to be aware of the change.

It also adds tst.py to the .gitignore so oone can easily work on it.